### PR TITLE
Retrieve bitstring for basic_bloom_filter

### DIFF
--- a/src/bf/bloom_filter/basic.cc
+++ b/src/bf/bloom_filter/basic.cc
@@ -83,6 +83,11 @@ void basic_bloom_filter::clear()
   bits_.reset();
 }
 
+std::string basic_bloom_filter::bitstring() const
+{
+  return to_string(bits_);
+}
+
 void basic_bloom_filter::remove(object const& o)
 {
   for (auto d : hasher_(o))

--- a/src/bf/bloom_filter/basic.h
+++ b/src/bf/bloom_filter/basic.h
@@ -2,6 +2,7 @@
 #define BF_BLOOM_FILTER_BASIC_H
 
 #include <random>
+#include <string>
 #include <bf/bitvector.h>
 #include <bf/bloom_filter.h>
 #include <bf/hash.h>
@@ -78,6 +79,9 @@ public:
   /// Swaps two basic Bloom filters.
   /// @param other The other basic Bloom filter.
   void swap(basic_bloom_filter& other);
+
+  /// Retrieves the stored bit string representation
+  std::string bitstring() const;
 
 private:
   hasher hasher_;


### PR DESCRIPTION
I created a method for retrieving the bitstring representation of a basic_bloom_filter. This is useful for storing the state of a Bloom filter.