### PR TITLE
Created a storage method to access bitvector

### DIFF
--- a/src/bf/bloom_filter/basic.cc
+++ b/src/bf/bloom_filter/basic.cc
@@ -96,4 +96,9 @@ void basic_bloom_filter::swap(basic_bloom_filter& other)
   swap(bits_, other.bits_);
 }
 
+bitvector const& basic_bloom_filter::storage() const
+{
+	return bits_;
+}
+
 } // namespace bf

--- a/src/bf/bloom_filter/basic.cc
+++ b/src/bf/bloom_filter/basic.cc
@@ -98,7 +98,7 @@ void basic_bloom_filter::swap(basic_bloom_filter& other)
 
 bitvector const& basic_bloom_filter::storage() const
 {
-	return bits_;
+  return bits_;
 }
 
 } // namespace bf

--- a/src/bf/bloom_filter/basic.h
+++ b/src/bf/bloom_filter/basic.h
@@ -79,6 +79,9 @@ public:
   /// @param other The other basic Bloom filter.
   void swap(basic_bloom_filter& other);
 
+  /// Returns the underlying storage of the Bloom filter.
+  bitvector const& storage() const;
+
 private:
   hasher hasher_;
   bitvector bits_;


### PR DESCRIPTION
This adds an interface for getting the underlying bitvector for a basic bloom filter. This is in response to [this](https://github.com/mavam/libbf/pull/10) pull request.