### PR TITLE
Have default hash function returns a `digest`

### DIFF
--- a/src/bf/hash.cc
+++ b/src/bf/hash.cc
@@ -9,7 +9,7 @@ default_hash_function::default_hash_function(size_t seed)
 {
 }
 
-size_t default_hash_function::operator()(object const& o) const
+digest default_hash_function::operator()(object const& o) const
 {
   // FIXME: fall back to a generic universal hash function (e.g., HMAC/MD5) for
   // too large objects.

--- a/src/bf/hash.h
+++ b/src/bf/hash.h
@@ -23,10 +23,10 @@ public:
 
   default_hash_function(size_t seed);
 
-  size_t operator()(object const& o) const;
+  digest operator()(object const& o) const;
 
 private:
-  h3<size_t, max_obj_size> h3_;
+  h3<digest, max_obj_size> h3_;
 };
 
 /// A hasher which hashes an object *k* times.


### PR DESCRIPTION
A more consistent signature of a default hash function.
