### PR TITLE
Fixed bloom_filter_bitwise test (issue #12)

### DIFF
--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -254,7 +254,7 @@ TEST(bloom_filter_spectral_rm) {
 }
 
 TEST(bloom_filter_bitwise) {
-  bitwise_bloom_filter bf(3, 8);
+  bitwise_bloom_filter bf(4, 8);
   CHECK_EQUAL(bf.lookup("foo"), 0u);
   bf.add("foo");
   CHECK_EQUAL(bf.lookup("foo"), 1u);


### PR DESCRIPTION
In a bitwise bloom filter test, the test passed with an additional hash function at the first level.
