### PR TITLE
Added make function for basic_bloom_filter

### DIFF
--- a/src/bf/bloom_filter/basic.cc
+++ b/src/bf/bloom_filter/basic.cc
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <utility>
 
 namespace bf {
 

--- a/src/bf/bloom_filter/basic.h
+++ b/src/bf/bloom_filter/basic.h
@@ -82,6 +82,21 @@ public:
   /// Returns the underlying storage of the Bloom filter.
   bitvector const& storage() const;
 
+  /// Makes a new basic_bloom_filter given a hasher and a bitvector.
+  ///
+  /// @param hasher The hasher to use.
+  /// @param bitvector the underlying bitvector of the bf.
+  ///
+  /// @return A basic_bloom_filter built from the given hasher and bitvector.
+  template<typename B>
+  static basic_bloom_filter make(hasher h, B&& b)
+  {
+    basic_bloom_filter bf(make_hasher(0), 0);
+    bf.hasher_ = h;
+    bf.bits_ = std::forward<B>(b);
+    return bf;
+  }
+
 private:
   hasher hasher_;
   bitvector bits_;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -171,6 +171,15 @@ TEST(bloom_filter_basic) {
   obf.swap(bf);
 
   CHECK_EQUAL(obf.lookup("foo"), 1u);
+
+  // Make bf using another filter's storage
+  auto c = basic_bloom_filter::m(0.8, 10);
+  auto k = basic_bloom_filter::k(c, 10);
+  auto h = make_hasher(k, 0, true);
+  bitvector b = obf.storage();
+  basic_bloom_filter obfc = basic_bloom_filter::make(h, obf.storage());
+  CHECK_EQUAL(obfc.lookup("foo"), 1u);
+
 }
 
 TEST(bloom_filter_counting) {


### PR DESCRIPTION
This is a version that uses universal reference. It is equivalent, but it will allow to save a copy of bitvector when it will become movable.