### PR TITLE
Fixed bug in counting_bloom_filter::lookup

### DIFF
--- a/src/bloom_filter/counting.cpp
+++ b/src/bloom_filter/counting.cpp
@@ -19,7 +19,7 @@ size_t counting_bloom_filter::lookup(object const& o) const {
   for (auto i : find_indices(o)) {
     auto cnt = cells_.count(i);
     if (cnt < min)
-      return min = cnt;
+      min = cnt;
   }
   return min;
 }


### PR DESCRIPTION
counting_bloom_filter::lookup always returned the count in the first cell that is smaller than cells_.max()