### PR TITLE
Fix windows build for Visual Studio

### DIFF
--- a/src/bitvector.cpp
+++ b/src/bitvector.cpp
@@ -1,5 +1,6 @@
 #include <bf/bitvector.hpp>
 
+#include <algorithm>
 #include <cassert>
 
 namespace bf {


### PR DESCRIPTION
On Windows, this package requires `#include <algorith>` in `bitvector.cpp` to properly call `std::min`.

Similar issue in another project: https://github.com/bakercp/ofxIO/issues/16