### PR TITLE
GCC 10.1 needs include stderr if using a stderr

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -1,5 +1,7 @@
 #include <bf/hash.hpp>
 
+#include <stdexcept>
+
 #include <cassert>
 
 namespace bf {


### PR DESCRIPTION
Closes #52 